### PR TITLE
add support for _SERVER['REMOTE_USER']

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -79,6 +79,8 @@ class Auth implements \Piwik\Auth
             $httpLogin = $_SERVER['PHP_AUTH_USER'];
         } elseif (isset($_SERVER['HTTP_AUTH_USER'])) {
            $httpLogin = $_SERVER['HTTP_AUTH_USER'];
+	} elseif (isset($_SERVER['REMOTE_USER'])) {
+	   $httpLogin = $_SERVER['REMOTE_USER'];
         } elseif (isset($_ENV['AUTH_USER'])) {
             $httpLogin = $_ENV['AUTH_USER'];
         } elseif (isset($_ENV['REMOTE_USER'])) {


### PR DESCRIPTION
Add $_SERVER['REMOTE_USER'] to the list of places we look for the username.

We use php-fpm with PHP 5.6 and Apache 2.4 on Redhat Enterprise Linux.  In this configuration, the other variables you check aren't passed from Apache to PHP, but $_SERVER['REMOTE_USER'] is.
